### PR TITLE
Renames SerializedLocation to SerializableLocation

### DIFF
--- a/packages/ui/browser/src/ts/Router.ts
+++ b/packages/ui/browser/src/ts/Router.ts
@@ -68,7 +68,7 @@ export interface SerializedLocation {
 }
 
 const serialize = (location: Location): SerializedLocation => ({
-    hash: location.hash,
+    hash: location.hash.substring(1),
     hostname: location.hostname,
     pathname: location.pathname,
     search: location.search,


### PR DESCRIPTION
Removes the leading hash from the SerializedLocation returned from the router.

# Def. of Done
- [x] Changes described in changelog.md 📝 
- [ ] Automatic tests written 🧪
- [ ] Manually tested 🧪
- [x] Good code style
- [x] Necessary migrate instructions added to migrate.md 🚀
- [x] No known issues
