### PR TITLE
fix(ui-browser): parent sets child visibility

### DIFF
--- a/packages/ui/browser/src/ts/HtmlComponent.ts
+++ b/packages/ui/browser/src/ts/HtmlComponent.ts
@@ -438,7 +438,7 @@ export class HtmlComponent implements Destroyable {
      * @param visible
      */
     protected parentVisibilityChanged(visible: boolean): void {
-        this.fireVisibilityChange(visible);
+        this.fireVisibilityChange(visible && this.isVisible());
     }
 
     /**


### PR DESCRIPTION
Checks child visibility when parent's visibility changes before calling
the child's visibility change handler.

# Def. of Done
- [ ] Changes described in changelog.md 📝 
- [ ] Automatic tests written 🧪
- [x] Manually tested 🧪
- [x] Good code style
